### PR TITLE
(3p) LSC: Remove `Lint as` gpylint comment directives.

### DIFF
--- a/iitch/BUILD
+++ b/iitch/BUILD
@@ -14,6 +14,15 @@
 
 load("@pipdeps//:requirements.bzl", "requirement")
 
+load("//tools/build_defs/license:license.bzl", "license")
+
+package(default_applicable_licenses = ["//third_party/py/iitch:license"])
+
+license(
+    name = "license",
+    package_name = "iitch",
+)
+
 licenses(["notice"])
 
 exports_files(["LICENSE"])

--- a/iitch/abmosquito/BUILD
+++ b/iitch/abmosquito/BUILD
@@ -14,7 +14,7 @@
 
 # Agent based modeling of mosquito population and animations
 
-licenses(["notice"])  # Apache License 2.0
+licenses(["notice"])
 
 py_library(
     name = "abmosquito",

--- a/iitch/abmosquito/BUILD
+++ b/iitch/abmosquito/BUILD
@@ -16,6 +16,8 @@
 
 load("//tools/build_defs/build_test:build_test.bzl", "build_test")
 
+package(default_applicable_licenses = ["//third_party/py/iitch:license"])
+
 licenses(["notice"])
 
 py_library(

--- a/iitch/abmosquito/BUILD
+++ b/iitch/abmosquito/BUILD
@@ -14,6 +14,8 @@
 
 # Agent based modeling of mosquito population and animations
 
+load("//tools/build_defs/build_test:build_test.bzl", "build_test")
+
 licenses(["notice"])
 
 py_library(
@@ -29,4 +31,9 @@ py_library(
         requirement("scipy"),
         requirement("six"),
     ],
+)
+
+build_test(
+    name = "abmosquito_build_test",
+    targets = [":abmosquito"],
 )

--- a/iitch/abmosquito/animation.py
+++ b/iitch/abmosquito/animation.py
@@ -1,4 +1,3 @@
-# Lint as: python2, python3
 # Copyright 2019 Verily Life Sciences LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/iitch/abmosquito/mosquito_abm.py
+++ b/iitch/abmosquito/mosquito_abm.py
@@ -1,4 +1,3 @@
-# Lint as: python2, python3
 # Copyright 2019 Verily Life Sciences LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/iitch/hierarchical_model/BUILD
+++ b/iitch/hierarchical_model/BUILD
@@ -14,6 +14,8 @@
 
 # Implementation of a hierarchical population dispersion model.
 
+load("//tools/build_defs/build_test:build_test.bzl", "build_test")
+
 licenses(["notice"])  # Apache License 2.0
 
 py_library(
@@ -33,4 +35,9 @@ py_library(
         requirement("tensorflow"),
         requirement("tensorflow_probability"),
     ],
+)
+
+build_test(
+    name = "hierarchical_model_build_test",
+    targets = [":hierarchical_model"],
 )

--- a/iitch/hierarchical_model/BUILD
+++ b/iitch/hierarchical_model/BUILD
@@ -16,6 +16,8 @@
 
 load("//tools/build_defs/build_test:build_test.bzl", "build_test")
 
+package(default_applicable_licenses = ["//third_party/py/iitch:license"])
+
 licenses(["notice"])  # Apache License 2.0
 
 py_library(

--- a/iitch/requirements.txt
+++ b/iitch/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.6
 tensorflow-probability
 numpy
 pandas


### PR DESCRIPTION
(3p) LSC: Remove `Lint as` gpylint comment directives.

This removes the `# [Lint as:] python{2,3}` header comments that used to tell
gpylint how to parse the file. Gpylint no longer supports that, so these
comments are noops that can be removed.

More information: go/remove-lint-as-lsc and b/181807094

BEGIN_PUBLIC
Remove unused comments related to Python 2 compatibility.
END_PUBLIC

Tested:
    TAP found no affected targets. No targets were built or tested.
    http://test/OCL:441673008:BASE:441674394:1649920083292:5e6420eb
